### PR TITLE
tweaks

### DIFF
--- a/defaults.yml
+++ b/defaults.yml
@@ -45,6 +45,7 @@ all_brew_packages:
   # Shell customization
   - starship
   - zsh-autosuggestions
+  - zsh-history-substring-search
   - zsh-syntax-highlighting
 
   # Kubernetes tools
@@ -88,6 +89,7 @@ all_brew_cask_packages:
   # Development tools
   - docker
   - gitbutler
+  - postman
   - visual-studio-code
   - wezterm
   - zed

--- a/dotfiles/zed/settings.json
+++ b/dotfiles/zed/settings.json
@@ -14,11 +14,11 @@
   "agent": {
     "default_model": {
       "provider": "copilot_chat",
-      "model": "gemini-2.5-pro"
+      "model": "claude-sonnet-4"
     },
     "inline_assistant_model": {
       "provider": "copilot_chat",
-      "model": "gemini-2.5-pro"
+      "model": "claude-sonnet-4"
     },
 
     "enable_feedback": false,
@@ -43,19 +43,20 @@
   },
   "icon_theme": "Catppuccin Latte",
 
-  // General font size
   "ui_font_size": 16,
   "ui_font_weight": 400,
   "ui_font_family": "Roboto Flex",
-  // Editor font size
-  "buffer_font_size": 15,
+
+  "buffer_font_size": 14.5,
   "buffer_font_weight": 400,
-  "buffer_font_family": "JetBrains Mono",
+  "buffer_font_family": "JetBrainsMono Nerd Font",
+  "buffer_font_fallbacks": ["JetBrains Mono", ".ZedMono"],
+  "buffer_font_features": { "calt": true },
   "buffer_line_height": "standard",
-  "gutter": {
-    // 3 digits is actually enough to display 4
-    "min_line_number_digits": 3
-  },
+
+  // 3 digits is actually enough to display 4
+  "gutter": { "min_line_number_digits": 3 },
+
   "minimap": {
     "show": "auto",
     "current_line_highlight": "all"
@@ -69,9 +70,11 @@
   "terminal": {
     "blinking": "on",
     "cursor_shape": "bar",
-    "font_family": "JetBrainsMono Nerd Font",
+
     "font_size": 13,
     "font_weight": 600,
+    "font_family": "JetBrainsMono Nerd Font",
+    "font_fallbacks": ["JetBrains Mono", ".ZedMono"],
     "font_features": { "calt": true },
     "line_height": { "custom": 1.45 }
   },

--- a/dotfiles/zsh/zshrc
+++ b/dotfiles/zsh/zshrc
@@ -1,5 +1,5 @@
 # TFSwitch
-path+=('/Users/shurgentum/bin')
+path+=("$HOME/bin")
 
 # NVM
 export NVM_DIR="$HOME/.nvm"
@@ -15,8 +15,16 @@ eval "$(pyenv init - zsh)"
 
 alias rosetta=arch -x86_64
 
+# Plugins
 source "$(brew --prefix)/share/zsh-autosuggestions/zsh-autosuggestions.zsh"
 source "$(brew --prefix)/share/zsh-syntax-highlighting/zsh-syntax-highlighting.zsh"
+# zsh-syntax-highlighting must load before zsh-history-substring-search for it to work properly
+source "$(brew --prefix)/share/zsh-history-substring-search/zsh-history-substring-search.zsh"
+HISTORY_SUBSTRING_SEARCH_ENSURE_UNIQUE=1
+HISTORY_SUBSTRING_SEARCH_HIGHLIGHT_FOUND=''
+HISTORY_SUBSTRING_SEARCH_HIGHLIGHT_NOT_FOUND=''
+bindkey '^[[A' history-substring-search-up
+bindkey '^[[B' history-substring-search-down
 
 export STARSHIP_CONFIG=$HOME/.config/starship/starship.toml
 eval "$(starship init zsh)"


### PR DESCRIPTION
Summary
- De buffer font size by 0.5
- Changed default font to JetBrainsMono Nerd Font with fallbacks to JetBrains Mono and .ZedMono for buffer and terminal
- Switched agent models from Gemini 2.5 Pro to Claude Sonnet 4
- Added zsh-history-substring-search plugin and configuration
- Made tfswitch static path dynamic
- Added Postman Homebrew cask package