### PR TITLE
feat: add dev tools, update shell and Zed config

### DIFF
--- a/defaults.work.yml
+++ b/defaults.work.yml
@@ -34,6 +34,8 @@ all_brew_packages:
   - zstd
 
   # Shell customization & utilities
+  - bat
+  - eza
   - fastfetch
   - starship
   - zsh-autosuggestions
@@ -66,8 +68,6 @@ all_brew_packages:
   - golangci-lint
   - nvm
   - php
-  - pyenv
-  - pyenv-virtualenv
   - ruff
 
   # IaaC tools

--- a/defaults.yml
+++ b/defaults.yml
@@ -33,6 +33,8 @@ all_brew_packages:
   - zstd
 
   # Shell customization & utilities
+  - bat
+  - eza
   - fastfetch
   - starship
   - zsh-autosuggestions
@@ -43,6 +45,7 @@ all_brew_packages:
   - argocd
   - awscli
   - gh
+  - gitbutler
   - glab
   - go-task
   - htop
@@ -60,6 +63,7 @@ all_brew_packages:
   - minikube
 
   # Programming tools
+  - deno
   - go
   - golangci-lint
   - gopls
@@ -97,6 +101,7 @@ all_brew_cask_packages:
 
   # Development tools
   - docker-desktop
+  - flutter
   - gitbutler
   - postman
   - visual-studio-code
@@ -132,6 +137,7 @@ mas_install_apps:
   - { id: "1236045954", name: "Canary Mail" }
   - { id: "571213070", name: "DaVinci Resolve" }
   - { id: "1437226581", name: "Horo timer" }
+  - { id: "497799835", name: "XCode" }
 
   # Paid apps
   - { id: "1289583905", name: "Pixelmator Pro" }

--- a/dotfiles/zed/settings.json
+++ b/dotfiles/zed/settings.json
@@ -16,13 +16,10 @@
       "max_tokens": 150,
       "model": "codestral-latest",
     },
-
-    "sweep": {
-      "privacy_mode": true,
-    },
   },
 
   "agent": {
+    "dock": "right",
     "show_turn_stats": true,
     "use_modifier_to_send": true,
     "default_model": {
@@ -57,11 +54,6 @@
       {
         "provider": "openrouter",
         "model": "anthropic/claude-haiku-4.5",
-        "enable_thinking": false,
-      },
-      {
-        "provider": "openrouter",
-        "model": "minimax/minimax-m2.5",
         "enable_thinking": false,
       },
     ],
@@ -126,6 +118,9 @@
     "dock": "left",
     "entry_spacing": "standard",
     "indent_size": 15,
+  },
+  "outline_panel": {
+    "dock": "left",
   },
   "collaboration_panel": { "button": false },
   // Git panel
@@ -228,6 +223,7 @@
     "catppuccin-icons": true,
 
     "ansible": true,
+    "deno": true,
     "dockerfile": true,
     "git-firefly": true,
     "html": true,

--- a/dotfiles/zsh/zshrc
+++ b/dotfiles/zsh/zshrc
@@ -49,7 +49,8 @@ alias rosetta=arch -x86_64
 alias watch='watch -n 2 --color '
 
 alias k='kubectl'
-alias ll='ls -laGh'
+alias ll='eza --long --no-time --no-user --no-filesize --icons --group-directories-first --git'
+alias pcat='bat -pP'
 
 # Starship Prompt
 export STARSHIP_CONFIG=$HOME/.config/starship/starship.toml


### PR DESCRIPTION
## Zed
- removed minimax from starred models
- removed sweep configuration due to it's deprecation
- explicitly docked agent to the right
- explicitly docked outline to the left
- added deno extension
## Homebrew
- added bat, eza, gitbutler and deno tools
- added flutter
- added XCode app
## ZSH
- added aliases for eza and bat

### Fixes:
- removed deprecated peen and pyenv-virtualenv from work profile